### PR TITLE
Allow loading testbench RAM from binary file

### DIFF
--- a/opa_sim_tb.vhd
+++ b/opa_sim_tb.vhd
@@ -40,6 +40,8 @@ use work.opa_functions_pkg.all;  -- for f_opa_safe
 use work.opa_components_pkg.all; -- for opa_lfsr
 
 entity opa_sim_tb is
+  generic (
+    init_file : string := "");
 end opa_sim_tb;
 
 architecture rtl of opa_sim_tb is
@@ -83,6 +85,26 @@ architecture rtl of opa_sim_tb is
   
 begin
 
+  p_load_ram : process
+    type t_char_file is file of character;
+    file fp : t_char_file;
+    variable cbuf : character;
+    variable cnt  : integer := 0;
+  begin
+    if init_file /= "" then
+      file_open(fp, init_file, READ_MODE);
+      cnt := 0;
+      while not endfile(fp) loop
+        read(fp, cbuf);
+        ram(cnt/4)(8*(cnt mod 4) +7 downto 8*(cnt mod 4)) :=
+          std_logic_vector(to_unsigned(character'POS(cbuf), 8));
+        cnt := cnt+1;
+      end loop;
+      file_close(fp);
+    end if;
+    wait;
+  end process;
+    
   clock : process
   begin
     clk <= '1';

--- a/opa_sim_tb.vhd
+++ b/opa_sim_tb.vhd
@@ -79,7 +79,7 @@ architecture rtl of opa_sim_tb is
   signal p_data_o : std_logic_vector(c_config.reg_width  -1 downto 0);
   signal p_data_i : std_logic_vector(c_config.reg_width  -1 downto 0);
   
-  signal ram : t_word_array(c_demo_ram'range) := c_demo_ram;
+  shared variable ram : t_word_array(c_demo_ram'range) := c_demo_ram;
   
 begin
 
@@ -185,7 +185,7 @@ begin
           else
             for b in d_sel'range loop
               if d_sel(b) = '1' then
-                ram(da)((b+1)*8-1 downto b*8) <= d_data_o((b+1)*8-1 downto b*8);
+                ram(da)((b+1)*8-1 downto b*8) := d_data_o((b+1)*8-1 downto b*8);
               end if;
             end loop;
           end if;


### PR DESCRIPTION
Hi,

I'm adding FuseSoC support for opa. With this patch, the testbench RAM can be initialied from a binary file by setting the `init_file` generic. In FuseSoC this is done by running `fusesoc sim opa --init_file=/path/to/file`
